### PR TITLE
Credits - Off-center fix

### DIFF
--- a/game/src/credits/credits.asm
+++ b/game/src/credits/credits.asm
@@ -390,6 +390,7 @@ CreditInitPage::
   call VWFMeasureCharacterForCredits
   ld a, h
   add b
+  inc a
   ld b, a
   pop hl
   inc c


### PR DESCRIPTION
This fixes an issue where text wasn't centered correctly in the credits screen. The issue was that when calculating the positioning, it didn't take into account that there is a 1-pixel-wide gap between characters. Therefore, text would be farther to the right than it should have been. The more characters there are, the farther to the right the text would be. This was especially noticeable when different lines had different amounts of characters.

Examples of earlier, incorrect centering:

![M3_Credits_Staff_incorrect](https://user-images.githubusercontent.com/2187686/233719804-23eb8e43-2b42-4a34-b6c5-24190032dd7d.png) ![M3_Credits_Voices_incorrect](https://user-images.githubusercontent.com/2187686/233719818-8aa3f6b3-eaec-4e2e-9a4e-c16a8b70f977.png)

Examples of fixed centering:

![M3_Credits_Staff_fix](https://user-images.githubusercontent.com/2187686/233719891-2e4ee3b5-2fc3-4095-9231-b481da01e4f5.png) ![M3_Credits_Voices_fix](https://user-images.githubusercontent.com/2187686/233719900-6e1d70fc-0bd7-4630-a02c-38b1f57822fb.png)
